### PR TITLE
Remove overlap between MC closure and MC fakes regions

### DIFF
--- a/bin/analyze_WZctrl_SFstudy.cc
+++ b/bin/analyze_WZctrl_SFstudy.cc
@@ -2411,7 +2411,7 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       //std::cout << "applySignalRegionVeto: " << applySignalRegionVeto << std::endl; 
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {

--- a/bin/analyze_Zjetsctrl_fakes.cc
+++ b/bin/analyze_Zjetsctrl_fakes.cc
@@ -2307,7 +2307,7 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       //std::cout << "applySignalRegionVeto: " << applySignalRegionVeto << std::endl; 
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {

--- a/bin/analyze_hh_0l_4tau.cc
+++ b/bin/analyze_hh_0l_4tau.cc
@@ -1362,10 +1362,7 @@ int main(int argc, char* argv[])
     cutFlowHistManager->fillHistograms("MEt filters", evtWeightRecorder.get(central_or_shift_main));
 
     bool failsSignalRegionVeto = false;
-    if ( isMCClosure_t ) {
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
-      if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 4 ) failsSignalRegionVeto = true;
-    } else if ( hadTauSelection == kFakeable ) {
+    if ( hadTauSelection == kFakeable || isMCClosure_t ) {
       if ( tightHadTaus.size() >= 4 ) failsSignalRegionVeto = true;
     }
     if ( failsSignalRegionVeto ) {

--- a/bin/analyze_hh_1l_3tau.cc
+++ b/bin/analyze_hh_1l_3tau.cc
@@ -1670,8 +1670,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 1 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 3 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_1l_gen.cc
+++ b/bin/analyze_hh_1l_gen.cc
@@ -4379,7 +4379,7 @@ int main(int argc, char* argv[])
 
       bool failsSignalRegionVeto = false;
       if ( isMCClosure_e || isMCClosure_m ) {
-	bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+        const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
 	if ( applySignalRegionVeto && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {
 	if ( tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;

--- a/bin/analyze_hh_2l_2tau.cc
+++ b/bin/analyze_hh_2l_2tau.cc
@@ -1821,8 +1821,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 2 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 2 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_2lss.cc
+++ b/bin/analyze_hh_2lss.cc
@@ -1862,7 +1862,7 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 2 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {
       if ( tightLeptons.size() >= 2 ) failsSignalRegionVeto = true;

--- a/bin/analyze_hh_3l.cc
+++ b/bin/analyze_hh_3l.cc
@@ -2331,7 +2331,7 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       //std::cout << "applySignalRegionVeto: " << applySignalRegionVeto << std::endl; 
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {

--- a/bin/analyze_hh_3l_1tau.cc
+++ b/bin/analyze_hh_3l_1tau.cc
@@ -1692,8 +1692,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 1 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_3l_1tau_BCR.cc
+++ b/bin/analyze_hh_3l_1tau_BCR.cc
@@ -1682,8 +1682,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 1 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_3l_1tau_FakeCR.cc
+++ b/bin/analyze_hh_3l_1tau_FakeCR.cc
@@ -1669,8 +1669,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 1 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_3l_1tau_ZZCR.cc
+++ b/bin/analyze_hh_3l_1tau_ZZCR.cc
@@ -1691,8 +1691,8 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m || isMCClosure_t ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
-      bool applySignalRegionVeto_hadTau = isMCClosure_t && countFakeHadTaus(selHadTaus) >= 1;
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
+      const bool & applySignalRegionVeto_hadTau = isMCClosure_t;
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       if ( applySignalRegionVeto_hadTau && tightHadTaus.size() >= 1 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable || hadTauSelection == kFakeable ) {

--- a/bin/analyze_hh_3l_gen.cc
+++ b/bin/analyze_hh_3l_gen.cc
@@ -4467,7 +4467,7 @@ int main(int argc, char* argv[])
 
       bool failsSignalRegionVeto = false;
       if ( isMCClosure_e || isMCClosure_m ) {
-	bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+        const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
 	if ( applySignalRegionVeto && tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;
       } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {
 	if ( tightLeptons.size() >= 3 ) failsSignalRegionVeto = true;

--- a/bin/analyze_hh_4l.cc
+++ b/bin/analyze_hh_4l.cc
@@ -2051,7 +2051,7 @@ int main(int argc, char* argv[])
 
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto && tightLeptons.size() >= 4 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {
       if ( tightLeptons.size() >= 4 ) failsSignalRegionVeto = true;

--- a/bin/analyze_ttctrl_fakes.cc
+++ b/bin/analyze_ttctrl_fakes.cc
@@ -1913,7 +1913,7 @@ int main(int argc, char* argv[])
     
     bool failsSignalRegionVeto = false;
     if ( isMCClosure_e || isMCClosure_m ) {
-      bool applySignalRegionVeto_lepton = (isMCClosure_e && countFakeElectrons(selLeptons) >= 1) || (isMCClosure_m && countFakeMuons(selLeptons) >= 1);
+      const bool applySignalRegionVeto_lepton = (isMCClosure_e && countElectrons(selLeptons) > 0) || (isMCClosure_m && countMuons(selLeptons) > 0);
       if ( applySignalRegionVeto_lepton && tightLeptons.size() >= 2 ) failsSignalRegionVeto = true;
     } else if ( electronSelection == kFakeable || muonSelection == kFakeable ) {
       if ( tightLeptons.size() >= 2 ) failsSignalRegionVeto = true;


### PR DESCRIPTION
In our analysis we distinguish the following regions:
- signal region, where only prompt and tight objects are selected;
- fakes MC region, where all objects are required to pass the tight cuts but at least one of the objects needs to be non-prompt;
- MC closure regions for particular object flavors (electrons, muons or hadronic taus) that is identical to the fakes MC region, except that the object selection for a given flavor is relaxed to fakeable, and the events selected in this region are reweighted according to the fake factor (FF) method (meaning that a FF is applied if the event contains fakeable objects not passing the tight cuts).

By comparing MC closure to fakes MC region, we can derive shape and normalization systematics that quantify any mismodelling of the fake background estimation for this particular object flavor and event category. Ideally, the two should coincide (within their statistical uncertainties).

The issue is that if we relax the selection for a certain flavor, we need to also veto events in order to avoid double-counting some of the contributions in the MC closure region. The easiest way to see this is by an example: let's consider an event in 2lss channel where the muon is non-prompt and the electrons is prompt, and
1. both leptons pass the tight cuts; or
2. the electron passes the tight cuts but the muon passes only the fakeable cuts.

In the absence of any additional vetoes both cases are allowed in MC closure, while in fakes MC region only case 1 is allowed. Since case 2 is an approximation (or "a model") of case 1, we need to veto case 1 in MC closure.

Until now, the veto was implemented by counting the number of non-prompt tight objects of certain flavor in the MC closure region for this flavor. The veto eliminates case 1 from MC closure region in the example above. However, it doesn't work if we swap the "promptness" in the example, because it allows both types of events in the MC closure region again. It means that the current veto is not effective enough because more events are considered in the MC closure region than expected. The effect is probably larger in event categories with higher object multiplicity because of additional combinatorics of the selected objects. This was an oversight when we first designed the MC closure regions.

The proper way to do this is to veto all events in the MC closure region for a particular flavor if there are tight objects with this flavor in the event. In other words, all events that include tight objects with the flavor should be replaced by their equivalent contributions estimated with the FF method. Thus, none of the events selected in the MC closure region should contain tight objects that have the flavor.

---

This issue came up while studying the 2lss channel where we observed significant deficiency (not excess that this PR is describing) in MC closure compared to fakes MC. Turns out that there was a bug that misconfigured the MC closure jobs incorrectly in 2lss channel. The bug was also present in 0l+4tau and 1l+3tau channels. These problems were fixed in commits 8b6529f7dd677743f5e9e33d761b858befed69e5 and 417488a2cc136bef19bfec51a1f0c68a1e1c6a4c, respectively. Later testing confirmed that these bugs had the highest impact on the observed discrepancy. Minor items, such as using different fake rate weights when applying tight charge cut, or replacing reco-pt with cone-pt in the BDT evaluation, have already been implemented (see 7516d7e1944137fbd99c9c8f35b78037f4b37f8b, fb3f8e3281cb159daf2ba94290c01c20c22724ac and 5cc125bf2995d8546344c7cddf58a9ce379a9072).

The issue described in this PR has also a minor effect on the comparison of MC closure to fakes MC, but should nevertheless be fixed in order to make the procedure conceptually more valid.

If you agree with the changes presented in this PR, I'll mrege the PR and propagate the changes also to ttH and HH->bbWW analyses.