### PR TITLE
Use cone_p4

### DIFF
--- a/bin/analyze_hh_1l_3tau.cc
+++ b/bin/analyze_hh_1l_3tau.cc
@@ -1771,14 +1771,14 @@ int main(int argc, char* argv[])
     std::vector<SVfit4tauResult> svFit4tauResults_wMassConstraint = compSVfit4tau(
       *selLepton, *selHadTau_lead, *selHadTau_sublead, *selHadTau_third, met, chargeSumSelection_string, rnd, 125., 2.);
         
-    double dihiggsVisMass_sel = (selLepton->p4() + selHadTau_lead->p4() + selHadTau_sublead->p4() + selHadTau_third->p4()).mass();
+    double dihiggsVisMass_sel = (selLepton->cone_p4() + selHadTau_lead->p4() + selHadTau_sublead->p4() + selHadTau_third->p4()).mass();
     double dihiggsMass = ( svFit4tauResults_wMassConstraint.size() >= 1 && svFit4tauResults_wMassConstraint[0].isValidSolution_ ) ? 
       svFit4tauResults_wMassConstraint[0].dihiggs_mass_ : -1.;
 
     // CV: compute additional variables for BDT training Ntuple
-    Particle::LorentzVector p4_lep_tau1 = selLepton->p4() + selHadTau_lead->p4();
-    Particle::LorentzVector p4_lep_tau2 = selLepton->p4() + selHadTau_sublead->p4();
-    Particle::LorentzVector p4_lep_tau3 = selLepton->p4() + selHadTau_third->p4();
+    Particle::LorentzVector p4_lep_tau1 = selLepton->cone_p4() + selHadTau_lead->p4();
+    Particle::LorentzVector p4_lep_tau2 = selLepton->cone_p4() + selHadTau_sublead->p4();
+    Particle::LorentzVector p4_lep_tau3 = selLepton->cone_p4() + selHadTau_third->p4();
 
     double dphi_lep_tau_OS_pair1 = -1.;
     double dphi_lep_tau_OS_pair2 = -1.;
@@ -1798,7 +1798,7 @@ int main(int argc, char* argv[])
           if ( (*selHadTau2)->charge()*(*selHadTau3)->charge() > 0. ) continue;
           double dphi_lep_tau_OS = deltaPhi(selLepton->phi(), (*selHadTau1)->phi());
           double dphi_tau_tau_OS = deltaPhi((*selHadTau2)->phi(), (*selHadTau3)->phi());
-          double dphi_HHvis      = deltaPhi((selLepton->p4() + (*selHadTau1)->p4()).phi(), ((*selHadTau2)->p4() + (*selHadTau3)->p4()).phi());
+          double dphi_HHvis      = deltaPhi((selLepton->cone_p4() + (*selHadTau1)->p4()).phi(), ((*selHadTau2)->p4() + (*selHadTau3)->p4()).phi());
           if ( dphi_lep_tau_OS_pair1 == -1. && dphi_tau_tau_OS_pair1 == -1. ) 
           {
             dphi_lep_tau_OS_pair1 = dphi_lep_tau_OS;

--- a/bin/analyze_hh_2l_2tau.cc
+++ b/bin/analyze_hh_2l_2tau.cc
@@ -1932,29 +1932,29 @@ const HHWeightInterfaceCouplings * const hhWeight_couplings = new HHWeightInterf
     std::vector<SVfit4tauResult> svFit4tauResults_wMassConstraint = compSVfit4tau(
       *selLepton_lead, *selLepton_sublead, *selHadTau_lead, *selHadTau_sublead, met, chargeSumSelection_string, rnd, 125., 2.);
 
-    double dihiggsVisMass_sel = (selLepton_lead->p4() + selLepton_sublead->p4() + selHadTau_lead->p4() + selHadTau_sublead->p4()).mass();
+    double dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selHadTau_lead->p4() + selHadTau_sublead->p4()).mass();
     
     double dihiggsMass = ( svFit4tauResults_wMassConstraint.size() >= 1 && svFit4tauResults_wMassConstraint[0].isValidSolution_ ) ?
       svFit4tauResults_wMassConstraint[0].dihiggs_mass_ : -1.;
 
     // pre-compute BDT variables-1
-    const double deltaEta_lep1_lep2 = (selLepton_lead->p4() - selLepton_sublead->p4()).eta();
-    const double deltaEta_lep1_tau1 = (selLepton_lead->p4() - selHadTau_lead->p4()).eta();
-    const double deltaEta_lep1_tau2 = (selLepton_lead->p4() - selHadTau_sublead->p4()).eta();
-    const double deltaEta_lep2_tau1 = (selLepton_sublead->p4() - selHadTau_lead->p4()).eta();
-    const double deltaEta_lep2_tau2 = (selLepton_sublead->p4() - selHadTau_sublead->p4()).eta();
+    const double deltaEta_lep1_lep2 = (selLepton_lead->cone_p4() - selLepton_sublead->cone_p4()).eta();
+    const double deltaEta_lep1_tau1 = (selLepton_lead->cone_p4() - selHadTau_lead->p4()).eta();
+    const double deltaEta_lep1_tau2 = (selLepton_lead->cone_p4() - selHadTau_sublead->p4()).eta();
+    const double deltaEta_lep2_tau1 = (selLepton_sublead->cone_p4() - selHadTau_lead->p4()).eta();
+    const double deltaEta_lep2_tau2 = (selLepton_sublead->cone_p4() - selHadTau_sublead->p4()).eta();
     const double deltaEta_tau1_tau2 = (selHadTau_lead->p4() - selHadTau_sublead->p4()).eta();
-    const double deltaPhi_lep1_lep2 = (selLepton_lead->p4() - selLepton_sublead->p4()).phi();
-    const double deltaPhi_lep1_tau1 = (selLepton_lead->p4() - selHadTau_lead->p4()).phi();
-    const double deltaPhi_lep1_tau2 = (selLepton_lead->p4() - selHadTau_sublead->p4()).phi();
-    const double deltaPhi_lep2_tau1 = (selLepton_sublead->p4() - selHadTau_lead->p4()).phi();
-    const double deltaPhi_lep2_tau2 = (selLepton_sublead->p4() - selHadTau_sublead->p4()).phi();
+    const double deltaPhi_lep1_lep2 = (selLepton_lead->cone_p4() - selLepton_sublead->cone_p4()).phi();
+    const double deltaPhi_lep1_tau1 = (selLepton_lead->cone_p4() - selHadTau_lead->p4()).phi();
+    const double deltaPhi_lep1_tau2 = (selLepton_lead->cone_p4() - selHadTau_sublead->p4()).phi();
+    const double deltaPhi_lep2_tau1 = (selLepton_sublead->cone_p4() - selHadTau_lead->p4()).phi();
+    const double deltaPhi_lep2_tau2 = (selLepton_sublead->cone_p4() - selHadTau_sublead->p4()).phi();
     const double deltaPhi_tau1_tau2 = (selHadTau_lead->p4() - selHadTau_sublead->p4()).phi();
-    const double m_lep1_tau1 = (selLepton_lead->p4() + selHadTau_lead->p4()).mass();
-    const double m_lep2_tau1 = (selLepton_sublead->p4() + selHadTau_lead->p4()).mass();
-    const double m_lep1_tau2 = (selLepton_lead->p4() + selHadTau_sublead->p4()).mass();
-    const double m_lep2_tau2 = (selLepton_sublead->p4() + selHadTau_sublead->p4()).mass();
-    const double pt_HH_recoil = (selLepton_lead->p4() + selLepton_sublead->p4() + selHadTau_lead->p4() + selHadTau_sublead->p4() + met.p4()).pt();
+    const double m_lep1_tau1 = (selLepton_lead->cone_p4() + selHadTau_lead->p4()).mass();
+    const double m_lep2_tau1 = (selLepton_sublead->cone_p4() + selHadTau_lead->p4()).mass();
+    const double m_lep1_tau2 = (selLepton_lead->cone_p4() + selHadTau_sublead->p4()).mass();
+    const double m_lep2_tau2 = (selLepton_sublead->cone_p4() + selHadTau_sublead->p4()).mass();
+    const double pt_HH_recoil = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selHadTau_lead->p4() + selHadTau_sublead->p4() + met.p4()).pt();
     const double mT_lep1 = comp_MT_met(selLepton_lead, met.pt(), met.phi());
     const double mT_lep2 = comp_MT_met(selLepton_sublead, met.pt(), met.phi());
     const double dr_lep1_tau1 = deltaR(selLepton_lead->p4(),    selHadTau_lead->p4());
@@ -1996,7 +1996,7 @@ const HHWeightInterfaceCouplings * const hhWeight_couplings = new HHWeightInterf
     const double dr_leps = deltaR(selLepton_lead->p4(), selLepton_sublead->p4());
     const double dr_taus = deltaR(selHadTau_lead->p4(), selHadTau_sublead->p4());
     const double avg_dr_jet = comp_avg_dr_jet(selJets);
-    const Particle::LorentzVector ll_p4 = selLepton_lead->p4() + selLepton_sublead->p4();
+    const Particle::LorentzVector ll_p4 = selLepton_lead->cone_p4() + selLepton_sublead->cone_p4();
     const double Smin_llMEt = comp_Smin(ll_p4, met.p4().px(), met.p4().py());
     const double ptTauTauVis_sel = (selHadTau_lead->p4() + selHadTau_sublead->p4()).pt();
     const Particle::LorentzVector lltautau_p4 = ll_p4 + tautau_p4;
@@ -2009,9 +2009,9 @@ const HHWeightInterfaceCouplings * const hhWeight_couplings = new HHWeightInterf
     const RecoJet * selBJet_sublead = selJets_btag.size() > 1 ? selJets_btag.at(1) : nullptr;
 
     //-------- Boosted pairs finding algorithm 
-    std::map<std::string, ParticlePair*> boost_pair_map = ComputeBoostPairs(selLepton_lead->p4(),
+    std::map<std::string, ParticlePair*> boost_pair_map = ComputeBoostPairs(selLepton_lead->cone_p4(),
 								     selLepton_lead->charge(),
-								     selLepton_sublead->p4(),
+                                                                     selLepton_sublead->cone_p4(),
 								     selLepton_sublead->charge(),
 								     selHadTau_lead->p4(),
 								     selHadTau_lead->charge(),
@@ -2075,7 +2075,7 @@ const HHWeightInterfaceCouplings * const hhWeight_couplings = new HHWeightInterf
     if(selBJet_lead && selBJet_sublead)
     {
       topness_publishedChi2.fit(
-        selLepton_lead->p4(), selLepton_sublead->p4(),
+        selLepton_lead->cone_p4(), selLepton_sublead->cone_p4(),
         selBJet_lead->p4(),   selBJet_sublead->p4(),
         met.p4().px(),        met.p4().py()
       );
@@ -2087,7 +2087,7 @@ const HHWeightInterfaceCouplings * const hhWeight_couplings = new HHWeightInterf
     if(selBJet_lead && selBJet_sublead)
     {
       topness_fixedChi2.fit(
-        selLepton_lead->p4(), selLepton_sublead->p4(),
+        selLepton_lead->cone_p4(), selLepton_sublead->cone_p4(),
         selBJet_lead->p4(),   selBJet_sublead->p4(),
         met.p4().px(),        met.p4().py()
       );

--- a/bin/analyze_hh_2lss.cc
+++ b/bin/analyze_hh_2lss.cc
@@ -1510,9 +1510,9 @@ int main(int argc, char* argv[])
     cutFlowTable.update(">= 2 sel leptons", evtWeightRecorder.get(central_or_shift_main));
     cutFlowHistManager->fillHistograms(">= 2 sel leptons", evtWeightRecorder.get(central_or_shift_main));
     const RecoLepton* selLepton_lead = selLeptons[0];
-    const Particle::LorentzVector& selLeptonP4_lead = selLepton_lead->p4();
+    const Particle::LorentzVector& selLeptonP4_lead = selLepton_lead->cone_p4();
     const RecoLepton* selLepton_sublead = selLeptons[1];
-    const Particle::LorentzVector& selLeptonP4_sublead = selLepton_sublead->p4();
+    const Particle::LorentzVector& selLeptonP4_sublead = selLepton_sublead->cone_p4();
     const leptonChargeFlipGenMatchEntry& selLepton_genMatch = getLeptonChargeFlipGenMatch(leptonGenMatch_definitions, selLepton_lead, selLepton_sublead);
 
     // require exactly two leptons passing tight selection criteria, to avoid overlap with other channels
@@ -1973,10 +1973,10 @@ int main(int argc, char* argv[])
     }
 
     // compute signal extraction observables
-    double dihiggsVisMass_sel = (selJetP4 + selLepton_lead->p4() + selLepton_sublead->p4()).mass();
-    double dihiggsMass_wMet_sel = (selJetP4 + selLepton_lead->p4() + selLepton_sublead->p4() + met.p4()).mass();
+    double dihiggsVisMass_sel = (selJetP4 + selLepton_lead->cone_p4() + selLepton_sublead->cone_p4()).mass();
+    double dihiggsMass_wMet_sel = (selJetP4 + selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + met.p4()).mass();
     double jetMass_sel = mass_jj_W;
-    double leptonPairMass_sel = (selLepton_lead->p4() + selLepton_sublead->p4()).mass();
+    double leptonPairMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4()).mass();
     double leptonPairCharge_sel = selLepton_lead->charge() + selLepton_sublead->charge();
 
     //--- compute variables BDTs used to discriminate . . .

--- a/bin/analyze_hh_3l.cc
+++ b/bin/analyze_hh_3l.cc
@@ -3065,8 +3065,8 @@ int main(int argc, char* argv[])
 
     
     
-    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach0 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach0->p4() + met.p4()).phi(), 
-										   (selLepton1_H_WW_ll_Approach0->p4() + selLepton2_H_WW_ll_Approach0->p4()).phi());
+    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach0 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach0->cone_p4() + met.p4()).phi(),
+                                                                                   (selLepton1_H_WW_ll_Approach0->cone_p4() + selLepton2_H_WW_ll_Approach0->cone_p4()).phi());
     
     double dPhi_LeptonIdx3_Met_Approach0 = calculateAbsDeltaPhi(selLepton_H_WW_ljj_Approach0->phi(), met.phi());
 
@@ -3259,8 +3259,8 @@ int main(int argc, char* argv[])
     }
 
     
-    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach2 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach2->p4() + met.p4()).phi(), 
-										   (selLepton1_H_WW_ll_Approach2->p4() + selLepton2_H_WW_ll_Approach2->p4()).phi());
+    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach2 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach2->cone_p4() + met.p4()).phi(),
+                                                                                   (selLepton1_H_WW_ll_Approach2->cone_p4() + selLepton2_H_WW_ll_Approach2->cone_p4()).phi());
 
     double dPhi_LeptonIdx3_Met_Approach2 = calculateAbsDeltaPhi(selLepton_H_WW_ljj_Approach2->phi(), met.phi());
     
@@ -3440,8 +3440,8 @@ int main(int argc, char* argv[])
 
 
     
-    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach3 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach3->p4() + met.p4()).phi(), 
-										   (selLepton1_H_WW_ll_Approach3->p4() + selLepton2_H_WW_ll_Approach3->p4()).phi());
+    double dPhi_LeptonIdx3plusMet_LeptonIdx1plus2_Approach3 = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach3->cone_p4() + met.p4()).phi(),
+                                                                                   (selLepton1_H_WW_ll_Approach3->cone_p4() + selLepton2_H_WW_ll_Approach3->cone_p4()).phi());
 
     double dPhi_LeptonIdx3_Met_Approach3 = calculateAbsDeltaPhi(selLepton_H_WW_ljj_Approach3->phi(), met.phi());
 

--- a/bin/analyze_hh_3l.cc
+++ b/bin/analyze_hh_3l.cc
@@ -2716,7 +2716,7 @@ int main(int argc, char* argv[])
 
 
     
-    const Particle::LorentzVector lv_3l   = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4());
+    const Particle::LorentzVector lv_3l   = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4());
     double m3l                            = lv_3l.mass();
     double WTojjMass                      = -1.;
     double dihiggsVisMass_sel             = -1.;
@@ -2726,14 +2726,14 @@ int main(int argc, char* argv[])
 
     if (selJet1_Wjj && selJet2_Wjj) {
       WTojjMass          = (selJet1_Wjj->p4() + selJet2_Wjj->p4()).mass();
-      dihiggsVisMass_sel = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4()).mass();
-      dihiggsMass        = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4() + met.p4()).mass();
-      dihiggsVisMass_sel_inclusive1j = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4()).mass();
-      dihiggsMass_inclusive1j        = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4() + met.p4()).mass();
+      dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4()).mass();
+      dihiggsMass        = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4() + met.p4()).mass();
+      dihiggsVisMass_sel_inclusive1j = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4()).mass();
+      dihiggsMass_inclusive1j        = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4() + selJet2_Wjj->p4() + met.p4()).mass();
       
     } else if (selJet1_Wjj) {
-      dihiggsVisMass_sel_inclusive1j = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4()).mass();
-      dihiggsMass_inclusive1j        = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selJet1_Wjj->p4() + met.p4()).mass();
+      dihiggsVisMass_sel_inclusive1j = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4()).mass();
+      dihiggsMass_inclusive1j        = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selJet1_Wjj->p4() + met.p4()).mass();
       //WTojjMass = (selJet1_Wjj->p4()).mass();
     }    
     
@@ -2941,9 +2941,9 @@ int main(int argc, char* argv[])
     double mT_LeptonIdx2_Met_Approach0 = comp_MT_met(selLepton2_H_WW_ll_Approach0, met.pt(), met.phi());
     double mT_LeptonIdx3_Met_Approach0 = comp_MT_met(selLepton_H_WW_ljj_Approach0, met.pt(), met.phi());
     //
-    double m_LeptonIdx1_LeptonIdx2_Approach0 = (selLepton1_H_WW_ll_Approach0->p4() + selLepton2_H_WW_ll_Approach0->p4()).mass();
-    double m_LeptonIdx2_LeptonIdx3_Approach0 = (selLepton2_H_WW_ll_Approach0->p4() + selLepton_H_WW_ljj_Approach0->p4()).mass();
-    double m_LeptonIdx1_LeptonIdx3_Approach0 = (selLepton1_H_WW_ll_Approach0->p4() + selLepton_H_WW_ljj_Approach0->p4()).mass();
+    double m_LeptonIdx1_LeptonIdx2_Approach0 = (selLepton1_H_WW_ll_Approach0->cone_p4() + selLepton2_H_WW_ll_Approach0->cone_p4()).mass();
+    double m_LeptonIdx2_LeptonIdx3_Approach0 = (selLepton2_H_WW_ll_Approach0->cone_p4() + selLepton_H_WW_ljj_Approach0->cone_p4()).mass();
+    double m_LeptonIdx1_LeptonIdx3_Approach0 = (selLepton1_H_WW_ll_Approach0->cone_p4() + selLepton_H_WW_ljj_Approach0->cone_p4()).mass();
     //
     double dPhi_LeptonIdx1_LeptonIdx2_Approach0 = calculateAbsDeltaPhi(selLepton1_H_WW_ll_Approach0->phi(), selLepton2_H_WW_ll_Approach0->phi());
     double dPhi_LeptonIdx2_LeptonIdx3_Approach0 = calculateAbsDeltaPhi(selLepton2_H_WW_ll_Approach0->phi(), selLepton_H_WW_ljj_Approach0->phi());
@@ -2957,7 +2957,7 @@ int main(int argc, char* argv[])
     double dr_LeptonIdx2_LeptonIdx3_Approach0 = deltaR(selLepton2_H_WW_ll_Approach0->p4(), selLepton_H_WW_ljj_Approach0->p4());
     double dr_LeptonIdx1_LeptonIdx3_Approach0 = deltaR(selLepton1_H_WW_ll_Approach0->p4(), selLepton_H_WW_ljj_Approach0->p4());
     //
-    double m_LeptonIdx3_Jet1_Approach0  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach0->p4() + selJet1_Wjj->p4()).mass() : -1;
+    double m_LeptonIdx3_Jet1_Approach0  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach0->cone_p4() + selJet1_Wjj->p4()).mass() : -1;
     double dr_LeptonIdx3_Jet1_Approach0 = selJet1_Wjj ? deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJet1_Wjj->p4()) : -1;
     double m_LeptonIdx3_JetNear_Approach0;
     double dr_LeptonIdx3_JetNear_Approach0;
@@ -2966,10 +2966,10 @@ int main(int argc, char* argv[])
       if (deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJet1_Wjj->p4()) <
 	  deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJet2_Wjj->p4()) ) {
 	dr_LeptonIdx3_JetNear_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJet1_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach0  = (selLepton_H_WW_ljj_Approach0->p4() + selJet1_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach0  = (selLepton_H_WW_ljj_Approach0->cone_p4() + selJet1_Wjj->p4()).mass();
       } else {
 	dr_LeptonIdx3_JetNear_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJet2_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach0  = (selLepton_H_WW_ljj_Approach0->p4() + selJet2_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach0  = (selLepton_H_WW_ljj_Approach0->cone_p4() + selJet2_Wjj->p4()).mass();
       }
     }
     else
@@ -3037,8 +3037,8 @@ int main(int argc, char* argv[])
       dr_LeptonIdx3_2AK4jNear_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), lv_2AK4jNear);
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), lv_2AK4jNear);
       
-      m_LeptonIdx3_2AK4jNear_Approach0 = (selLepton_H_WW_ljj_Approach0->p4() + lv_2AK4jNear).mass();
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = (selLepton_H_WW_ljj_Approach0->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_Approach0 = (selLepton_H_WW_ljj_Approach0->cone_p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = (selLepton_H_WW_ljj_Approach0->cone_p4() + lv_2AK4jNear).mass();
 
       dr_2AK4J_NearestToLeptonIdx3_Approach0 = deltaR(selAK4J_closestToLeptonIdx3_Approach0->p4(), selAK4J_2ndclosestToLeptonIdx3_Approach0->p4());
     }
@@ -3046,7 +3046,7 @@ int main(int argc, char* argv[])
     {
       const Particle::LorentzVector lv_2AK4jNear = (selAK4J_closestToLeptonIdx3_Approach0->p4());
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), lv_2AK4jNear);
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = (selLepton_H_WW_ljj_Approach0->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach0 = (selLepton_H_WW_ljj_Approach0->cone_p4() + lv_2AK4jNear).mass();
     }
 
     if (selAK4J_closestToLeptonIdx3_Approach0)
@@ -3060,7 +3060,7 @@ int main(int argc, char* argv[])
     if (isWjjBoosted)
     {
       dr_LeptonIdx3_AK8_Approach0 = deltaR(selLepton_H_WW_ljj_Approach0->p4(), selJetAK8_Wjj->p4());
-      m_LeptonIdx3_AK8_Approach0 = (selLepton_H_WW_ljj_Approach0->p4() + selJetAK8_Wjj->p4()).mass();
+      m_LeptonIdx3_AK8_Approach0 = (selLepton_H_WW_ljj_Approach0->cone_p4() + selJetAK8_Wjj->p4()).mass();
     }
 
     
@@ -3090,7 +3090,7 @@ int main(int argc, char* argv[])
 	     v1.DeltaPhi(v2)
 	);
       std::cout << "TMath::Pi(): " << TMath::Pi() << "\n";
-      //std::cout << (selLepton1_H_WW_ll_Approach0->p4()).DeltaPhi(selLepton2_H_WW_ll_Approach0->p4()) << "\n";
+      //std::cout << (selLepton1_H_WW_ll_Approach0->cone_p4()).DeltaPhi(selLepton2_H_WW_ll_Approach0->cone_p4()) << "\n";
     }
 
     
@@ -3116,8 +3116,8 @@ int main(int argc, char* argv[])
       if (iLepton3 == idxLepton2_H_WW_ll_Approach2) iLepton3++;
       if (iLepton3 == iLepton1)                     iLepton3++;
       
-      if ((selLepton2_H_WW_ll_Approach2->p4() + selLeptons[iLepton1]->p4()).mass() <
-	  (selLepton2_H_WW_ll_Approach2->p4() + selLeptons[iLepton3]->p4()).mass() ) { // assume m(l1+l2) < m(l2+l3)
+      if ((selLepton2_H_WW_ll_Approach2->cone_p4() + selLeptons[iLepton1]->cone_p4()).mass() <
+          (selLepton2_H_WW_ll_Approach2->cone_p4() + selLeptons[iLepton3]->cone_p4()).mass() ) { // assume m(l1+l2) < m(l2+l3)
 	idxLepton1_H_WW_ll_Approach2 = iLepton1;
 	idxLepton_H_WW_ljj_Approach2 = iLepton3;
       } else { 
@@ -3129,8 +3129,8 @@ int main(int argc, char* argv[])
     selLepton_H_WW_ljj_Approach2 = selLeptons[idxLepton_H_WW_ljj_Approach2];
 
     // Complain if there is a mistake in picking leptons in Approach 2
-    if ((selLepton2_H_WW_ll_Approach2->p4() + selLepton1_H_WW_ll_Approach2->p4()).mass() >
-	(selLepton2_H_WW_ll_Approach2->p4() + selLepton_H_WW_ljj_Approach2->p4()).mass() ) { // mistake in picking leptons in Approach 2
+    if ((selLepton2_H_WW_ll_Approach2->cone_p4() + selLepton1_H_WW_ll_Approach2->cone_p4()).mass() >
+        (selLepton2_H_WW_ll_Approach2->cone_p4() + selLepton_H_WW_ljj_Approach2->cone_p4()).mass() ) { // mistake in picking leptons in Approach 2
       std::cout << "analyze_hh_3l: mistake in picking leptons in Approach 2" << std::endl;
       throw cmsException("analyze_hh_3l", __LINE__) << "Error in calculating dr_os n";
     }
@@ -3139,9 +3139,9 @@ int main(int argc, char* argv[])
     double mT_LeptonIdx2_Met_Approach2 = comp_MT_met(selLepton2_H_WW_ll_Approach2, met.pt(), met.phi());
     double mT_LeptonIdx3_Met_Approach2 = comp_MT_met(selLepton_H_WW_ljj_Approach2, met.pt(), met.phi());
     //
-    double m_LeptonIdx1_LeptonIdx2_Approach2 = (selLepton1_H_WW_ll_Approach2->p4() + selLepton2_H_WW_ll_Approach2->p4()).mass();
-    double m_LeptonIdx2_LeptonIdx3_Approach2 = (selLepton2_H_WW_ll_Approach2->p4() + selLepton_H_WW_ljj_Approach2->p4()).mass();
-    double m_LeptonIdx1_LeptonIdx3_Approach2 = (selLepton1_H_WW_ll_Approach2->p4() + selLepton_H_WW_ljj_Approach2->p4()).mass();
+    double m_LeptonIdx1_LeptonIdx2_Approach2 = (selLepton1_H_WW_ll_Approach2->cone_p4() + selLepton2_H_WW_ll_Approach2->cone_p4()).mass();
+    double m_LeptonIdx2_LeptonIdx3_Approach2 = (selLepton2_H_WW_ll_Approach2->cone_p4() + selLepton_H_WW_ljj_Approach2->cone_p4()).mass();
+    double m_LeptonIdx1_LeptonIdx3_Approach2 = (selLepton1_H_WW_ll_Approach2->cone_p4() + selLepton_H_WW_ljj_Approach2->cone_p4()).mass();
     //
     double dPhi_LeptonIdx1_LeptonIdx2_Approach2 = calculateAbsDeltaPhi(selLepton1_H_WW_ll_Approach2->phi(), selLepton2_H_WW_ll_Approach2->phi());
     double dPhi_LeptonIdx2_LeptonIdx3_Approach2 = calculateAbsDeltaPhi(selLepton2_H_WW_ll_Approach2->phi(), selLepton_H_WW_ljj_Approach2->phi());
@@ -3155,7 +3155,7 @@ int main(int argc, char* argv[])
     double dr_LeptonIdx2_LeptonIdx3_Approach2 = deltaR(selLepton2_H_WW_ll_Approach2->p4(), selLepton_H_WW_ljj_Approach2->p4());
     double dr_LeptonIdx1_LeptonIdx3_Approach2 = deltaR(selLepton1_H_WW_ll_Approach2->p4(), selLepton_H_WW_ljj_Approach2->p4());
     //
-    double m_LeptonIdx3_Jet1_Approach2  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach2->p4() + selJet1_Wjj->p4()).mass() : -1;
+    double m_LeptonIdx3_Jet1_Approach2  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach2->cone_p4() + selJet1_Wjj->p4()).mass() : -1;
     double dr_LeptonIdx3_Jet1_Approach2 = selJet1_Wjj ? deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJet1_Wjj->p4()) : -1;
     double m_LeptonIdx3_JetNear_Approach2;
     double dr_LeptonIdx3_JetNear_Approach2;
@@ -3163,10 +3163,10 @@ int main(int argc, char* argv[])
       if (deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJet1_Wjj->p4()) <
 	  deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJet2_Wjj->p4()) ) {
 	dr_LeptonIdx3_JetNear_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJet1_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach2  = (selLepton_H_WW_ljj_Approach2->p4() + selJet1_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach2  = (selLepton_H_WW_ljj_Approach2->cone_p4() + selJet1_Wjj->p4()).mass();
       } else {
 	dr_LeptonIdx3_JetNear_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJet2_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach2  = (selLepton_H_WW_ljj_Approach2->p4() + selJet2_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach2  = (selLepton_H_WW_ljj_Approach2->cone_p4() + selJet2_Wjj->p4()).mass();
       }
     } else {
       dr_LeptonIdx3_JetNear_Approach2 = dr_LeptonIdx3_Jet1_Approach2;
@@ -3232,8 +3232,8 @@ int main(int argc, char* argv[])
       dr_LeptonIdx3_2AK4jNear_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), lv_2AK4jNear);
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), lv_2AK4jNear);
       
-      m_LeptonIdx3_2AK4jNear_Approach2 = (selLepton_H_WW_ljj_Approach2->p4() + lv_2AK4jNear).mass();
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = (selLepton_H_WW_ljj_Approach2->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_Approach2 = (selLepton_H_WW_ljj_Approach2->cone_p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = (selLepton_H_WW_ljj_Approach2->cone_p4() + lv_2AK4jNear).mass();
 
       dr_2AK4J_NearestToLeptonIdx3_Approach2 = deltaR(selAK4J_closestToLeptonIdx3_Approach2->p4(), selAK4J_2ndclosestToLeptonIdx3_Approach2->p4());
     }
@@ -3241,7 +3241,7 @@ int main(int argc, char* argv[])
     {
       const Particle::LorentzVector lv_2AK4jNear = (selAK4J_closestToLeptonIdx3_Approach2->p4());
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), lv_2AK4jNear);
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = (selLepton_H_WW_ljj_Approach2->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach2 = (selLepton_H_WW_ljj_Approach2->cone_p4() + lv_2AK4jNear).mass();
     }
 
     if (selAK4J_closestToLeptonIdx3_Approach2)
@@ -3255,7 +3255,7 @@ int main(int argc, char* argv[])
     if (isWjjBoosted)
     {
       dr_LeptonIdx3_AK8_Approach2 = deltaR(selLepton_H_WW_ljj_Approach2->p4(), selJetAK8_Wjj->p4());
-      m_LeptonIdx3_AK8_Approach2 = (selLepton_H_WW_ljj_Approach2->p4() + selJetAK8_Wjj->p4()).mass();
+      m_LeptonIdx3_AK8_Approach2 = (selLepton_H_WW_ljj_Approach2->cone_p4() + selJetAK8_Wjj->p4()).mass();
     }
 
     
@@ -3319,9 +3319,9 @@ int main(int argc, char* argv[])
     double mT_LeptonIdx2_Met_Approach3 = comp_MT_met(selLepton2_H_WW_ll_Approach3, met.pt(), met.phi());
     double mT_LeptonIdx3_Met_Approach3 = comp_MT_met(selLepton_H_WW_ljj_Approach3, met.pt(), met.phi());
     //
-    double m_LeptonIdx1_LeptonIdx2_Approach3 = (selLepton1_H_WW_ll_Approach3->p4() + selLepton2_H_WW_ll_Approach3->p4()).mass();
-    double m_LeptonIdx2_LeptonIdx3_Approach3 = (selLepton2_H_WW_ll_Approach3->p4() + selLepton_H_WW_ljj_Approach3->p4()).mass();
-    double m_LeptonIdx1_LeptonIdx3_Approach3 = (selLepton1_H_WW_ll_Approach3->p4() + selLepton_H_WW_ljj_Approach3->p4()).mass();
+    double m_LeptonIdx1_LeptonIdx2_Approach3 = (selLepton1_H_WW_ll_Approach3->cone_p4() + selLepton2_H_WW_ll_Approach3->cone_p4()).mass();
+    double m_LeptonIdx2_LeptonIdx3_Approach3 = (selLepton2_H_WW_ll_Approach3->cone_p4() + selLepton_H_WW_ljj_Approach3->cone_p4()).mass();
+    double m_LeptonIdx1_LeptonIdx3_Approach3 = (selLepton1_H_WW_ll_Approach3->cone_p4() + selLepton_H_WW_ljj_Approach3->cone_p4()).mass();
     //
     double dPhi_LeptonIdx1_LeptonIdx2_Approach3 = calculateAbsDeltaPhi(selLepton1_H_WW_ll_Approach3->phi(), selLepton2_H_WW_ll_Approach3->phi());
     double dPhi_LeptonIdx2_LeptonIdx3_Approach3 = calculateAbsDeltaPhi(selLepton2_H_WW_ll_Approach3->phi(), selLepton_H_WW_ljj_Approach3->phi());
@@ -3335,7 +3335,7 @@ int main(int argc, char* argv[])
     double dr_LeptonIdx2_LeptonIdx3_Approach3 = deltaR(selLepton2_H_WW_ll_Approach3->p4(), selLepton_H_WW_ljj_Approach3->p4());
     double dr_LeptonIdx1_LeptonIdx3_Approach3 = deltaR(selLepton1_H_WW_ll_Approach3->p4(), selLepton_H_WW_ljj_Approach3->p4());
     //
-    double m_LeptonIdx3_Jet1_Approach3  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach3->p4() + selJet1_Wjj->p4()).mass() : -1;
+    double m_LeptonIdx3_Jet1_Approach3  = selJet1_Wjj ? (selLepton_H_WW_ljj_Approach3->cone_p4() + selJet1_Wjj->p4()).mass() : -1;
     double dr_LeptonIdx3_Jet1_Approach3 = selJet1_Wjj ? deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJet1_Wjj->p4()) : -1;
     double m_LeptonIdx3_JetNear_Approach3;
     double dr_LeptonIdx3_JetNear_Approach3;
@@ -3343,10 +3343,10 @@ int main(int argc, char* argv[])
       if (deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJet1_Wjj->p4()) <
 	  deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJet2_Wjj->p4()) ) {
 	dr_LeptonIdx3_JetNear_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJet1_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach3  = (selLepton_H_WW_ljj_Approach3->p4() + selJet1_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach3  = (selLepton_H_WW_ljj_Approach3->cone_p4() + selJet1_Wjj->p4()).mass();
       } else {
 	dr_LeptonIdx3_JetNear_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJet2_Wjj->p4());
-	m_LeptonIdx3_JetNear_Approach3  = (selLepton_H_WW_ljj_Approach3->p4() + selJet2_Wjj->p4()).mass();
+        m_LeptonIdx3_JetNear_Approach3  = (selLepton_H_WW_ljj_Approach3->cone_p4() + selJet2_Wjj->p4()).mass();
       }
     } else {
       dr_LeptonIdx3_JetNear_Approach3 = dr_LeptonIdx3_Jet1_Approach3;
@@ -3412,8 +3412,8 @@ int main(int argc, char* argv[])
       dr_LeptonIdx3_2AK4jNear_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), lv_2AK4jNear);
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), lv_2AK4jNear);
       
-      m_LeptonIdx3_2AK4jNear_Approach3 = (selLepton_H_WW_ljj_Approach3->p4() + lv_2AK4jNear).mass();
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = (selLepton_H_WW_ljj_Approach3->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_Approach3 = (selLepton_H_WW_ljj_Approach3->cone_p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = (selLepton_H_WW_ljj_Approach3->cone_p4() + lv_2AK4jNear).mass();
 
       dr_2AK4J_NearestToLeptonIdx3_Approach3 = deltaR(selAK4J_closestToLeptonIdx3_Approach3->p4(), selAK4J_2ndclosestToLeptonIdx3_Approach3->p4());
     }
@@ -3421,7 +3421,7 @@ int main(int argc, char* argv[])
     {
       const Particle::LorentzVector lv_2AK4jNear = (selAK4J_closestToLeptonIdx3_Approach3->p4());
       dr_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), lv_2AK4jNear);
-      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = (selLepton_H_WW_ljj_Approach3->p4() + lv_2AK4jNear).mass();
+      m_LeptonIdx3_2AK4jNear_inclusive1j_Approach3 = (selLepton_H_WW_ljj_Approach3->cone_p4() + lv_2AK4jNear).mass();
     }
 
     if (selAK4J_closestToLeptonIdx3_Approach3)
@@ -3435,7 +3435,7 @@ int main(int argc, char* argv[])
     if (isWjjBoosted)
     {
       dr_LeptonIdx3_AK8_Approach3 = deltaR(selLepton_H_WW_ljj_Approach3->p4(), selJetAK8_Wjj->p4());
-      m_LeptonIdx3_AK8_Approach3 = (selLepton_H_WW_ljj_Approach3->p4() + selJetAK8_Wjj->p4()).mass();
+      m_LeptonIdx3_AK8_Approach3 = (selLepton_H_WW_ljj_Approach3->cone_p4() + selJetAK8_Wjj->p4()).mass();
     }
 
 
@@ -3457,7 +3457,7 @@ int main(int argc, char* argv[])
     {
       dPhi_2lSFOS_one2lSFOSEvt = calculateAbsDeltaPhi(selLepton1_H_WW_ll_Approach3->phi(), selLepton2_H_WW_ll_Approach3->phi());
       dR_2lSFOS_one2lSFOSEvt = deltaR(selLepton1_H_WW_ll_Approach3->p4(), selLepton2_H_WW_ll_Approach3->p4());
-      m_2lSFOS_one2lSFOSEvt = (selLepton1_H_WW_ll_Approach3->p4() + selLepton2_H_WW_ll_Approach3->p4()).mass();
+      m_2lSFOS_one2lSFOSEvt = (selLepton1_H_WW_ll_Approach3->cone_p4() + selLepton2_H_WW_ll_Approach3->cone_p4()).mass();
 
       mT_LeptonNonSFOS_Met_one2lSFOSEvt = comp_MT_met(selLepton_H_WW_ljj_Approach3, met.pt(), met.phi());
       dPhi_LeptonNonSFOS_Met_one2lSFOSEvt = calculateAbsDeltaPhi((selLepton_H_WW_ljj_Approach3)->phi(), 
@@ -3540,7 +3540,7 @@ int main(int argc, char* argv[])
       }
       
       jetMass_sel_WZctrl_2lss        = WTojjMass;
-      leptonPairMass_sel_WZctrl_2lss = (selLepton1_SS->p4() + selLepton2_SS->p4()).mass();
+      leptonPairMass_sel_WZctrl_2lss = (selLepton1_SS->cone_p4() + selLepton2_SS->cone_p4()).mass();
       mindr_lep1_jet_WZctrl_2lss     = std::min(10., comp_mindr_jet(*selLepton1_SS, selJetsAK4));
       mT_lep1_WZctrl_2lss            = comp_MT_met(selLepton1_SS, met.pt(), met.phi());
       mindr_lep2_jet_WZctrl_2lss     = std::min(10., comp_mindr_jet(*selLepton2_SS, selJetsAK4));

--- a/bin/analyze_hh_3l_1tau.cc
+++ b/bin/analyze_hh_3l_1tau.cc
@@ -1774,7 +1774,7 @@ int main(int argc, char* argv[])
     //std::vector<SVfit4tauResult> svFit4tauResults_wMassConstraint_Z = compSVfit4tau(
     //  *selLepton_lead, *selLepton_sublead, *selLepton_third, *selHadTau, met, chargeSumSelection_string, rnd, 91.2, 2.);
 
-    double dihiggsVisMass_sel = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selHadTau->p4()).mass();
+    double dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selHadTau->cone_p4()).mass();
     //double dihiggsMass = ( svFit4tauResults_wMassConstraint.size() >= 1 && svFit4tauResults_wMassConstraint[0].isValidSolution_ ) ? 
     //  svFit4tauResults_wMassConstraint[0].dihiggs_mass_ : -1.;
 
@@ -1820,9 +1820,9 @@ int main(int argc, char* argv[])
     //--- retrieve gen-matching flags
     std::vector<const GenMatchEntry*> genMatches = genMatchInterface.getGenMatch(selLeptons, selHadTaus);
     //---additional evt variables
-    TLorentzVector lep1LV(selLepton_lead->p4().px(),selLepton_lead->p4().py(),selLepton_lead->p4().pz(),selLepton_lead->p4().energy());
-    TLorentzVector lep2LV(selLepton_sublead->p4().px(),selLepton_sublead->p4().py(),selLepton_sublead->p4().pz(),selLepton_sublead->p4().energy());
-    TLorentzVector lep3LV(selLepton_third->p4().px(),selLepton_third->p4().py(),selLepton_third->p4().pz(),selLepton_third->p4().energy());
+    TLorentzVector lep1LV(selLepton_lead->cone_p4().px(),selLepton_lead->cone_p4().py(),selLepton_lead->cone_p4().pz(),selLepton_lead->cone_p4().energy());
+    TLorentzVector lep2LV(selLepton_sublead->cone_p4().px(),selLepton_sublead->cone_p4().py(),selLepton_sublead->cone_p4().pz(),selLepton_sublead->cone_p4().energy());
+    TLorentzVector lep3LV(selLepton_third->cone_p4().px(),selLepton_third->cone_p4().py(),selLepton_third->cone_p4().pz(),selLepton_third->cone_p4().energy());
     TLorentzVector tau1LV(selHadTau->p4().px(),selHadTau->p4().py(),selHadTau->p4().pz(),selHadTau->p4().energy());
     TLorentzVector metLV(met.p4().px(),met.p4().py(),met.p4().pz(),met.p4().energy());
     double mT_nonZlepMET = -1;
@@ -1842,21 +1842,21 @@ int main(int argc, char* argv[])
       nSFOS = nSFOS + 1;
     }
     if( ((selLepton_lead->charge()*selLepton_sublead->charge())< 0.)&&(selLepton_lead_type==selLepton_sublead_type)){
-      mllOS_closestToZ = (selLepton_lead->p4()+selLepton_sublead->p4()).mass();
+      mllOS_closestToZ = (selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()).mass();
       mT_nonZlepMET = comp_MT_met(selLepton_third, met.pt(), met.phi());
       TLorentzVector temppair = tau1LV+lep3LV;
       mZ_tau = std::sqrt(2. * temppair.Pt() * met.pt() * (1. - std::cos(temppair.Phi() - met.phi())));
       dPhi_nonZlMET = TMath::Abs(metLV.DeltaPhi(lep3LV));
     }
     if( ( (selLepton_lead->charge()*selLepton_third->charge()) < 0. ) &&(selLepton_lead_type==selLepton_third_type)&& ( (mllOS_closestToZ <0) || ( TMath::Abs((selLepton_lead->p4()+selLepton_third->p4()).mass()-91.1876)< TMath::Abs(mllOS_closestToZ-91.1876) )) ){
-      mllOS_closestToZ = ((selLepton_lead->p4()+selLepton_third->p4()).mass());
+      mllOS_closestToZ = ((selLepton_lead->cone_p4()+selLepton_third->cone_p4()).mass());
       mT_nonZlepMET = comp_MT_met(selLepton_sublead, met.pt(), met.phi());
       TLorentzVector temppair = tau1LV+lep2LV;
       mZ_tau = std::sqrt(2. * temppair.Pt() * met.pt() * (1. - std::cos(temppair.Phi() - met.phi())));
       dPhi_nonZlMET = TMath::Abs(metLV.DeltaPhi(lep2LV));
     }
     if( ( (selLepton_sublead->charge()*selLepton_third->charge()) < 0. ) &&(selLepton_sublead_type==selLepton_third_type)&& ( (mllOS_closestToZ <0) || ( TMath::Abs((selLepton_sublead->p4()+selLepton_third->p4()).mass()-91.1876)< TMath::Abs(mllOS_closestToZ-91.1876) )) ){
-      mllOS_closestToZ = ((selLepton_sublead->p4()+selLepton_third->p4()).mass());
+      mllOS_closestToZ = ((selLepton_sublead->cone_p4()+selLepton_third->cone_p4()).mass());
       mT_nonZlepMET = comp_MT_met(selLepton_lead, met.pt(), met.phi());
       TLorentzVector temppair = tau1LV+lep1LV;
       mZ_tau = std::sqrt(2. * temppair.Pt() * met.pt() * (1. - std::cos(temppair.Phi() - met.phi())));
@@ -1891,7 +1891,7 @@ int main(int argc, char* argv[])
     }
     TLorentzVector temppair_hh = tau1LV+lep1LV+lep2LV+lep3LV;
     double mHHT_construct = std::sqrt(2. * temppair_hh.Pt() * met.pt() * (1. - std::cos(temppair_hh.Phi() - met.phi())));
-    double mHH_contruct =(selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()+ selHadTau->p4()+met.p4()).mass();
+    double mHH_contruct =(selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()+ selHadTau->p4()+met.p4()).mass();
 
     double dR_ltau_minltaupair = -1;
     double dEta_ltau_minltaupair = -1;
@@ -2148,12 +2148,12 @@ int main(int argc, char* argv[])
       pTDiff_smartpair1 = TMath::Abs(p2_p1LV.Pt()-p2_p2LV.Pt());
     }
 
-    double mlll = (selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()).mass();
-    double mAll = (selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()+ selHadTau->p4()).mass();
-    //    double pT4l = (selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()+ selHadTau->p4()).pt(); 
+    double mlll = (selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()).mass();
+    double mAll = (selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()+ selHadTau->p4()).mass();
+    //    double pT4l = (selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()+ selHadTau->p4()).pt();
     TLorentzVector allLep = lep1LV+lep2LV+lep3LV+tau1LV;
 
-    Particle::LorentzVector p4l = selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()+selHadTau->p4();
+    Particle::LorentzVector p4l = selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()+selHadTau->p4();
     TVector3 pt4lVetor(p4l.px(),p4l.py(),0);
     TVector3 metVector(met.p4().px(),met.p4().py(),0);
     TVector3 hadTVector = -metVector-pt4lVetor;
@@ -2208,9 +2208,9 @@ int main(int argc, char* argv[])
       //tau_antiElectron_unmatched=selHadTau->antiElectron();
     //}
     
-    double m_l1tau = (selLepton_lead->p4()+selHadTau->p4()).mass();
-    double m_l2tau = (selLepton_sublead->p4()+selHadTau->p4()).mass();
-    double m_l3tau = (selLepton_third->p4()+selHadTau->p4()).mass();
+    double m_l1tau = (selLepton_lead->cone_p4()+selHadTau->p4()).mass();
+    double m_l2tau = (selLepton_sublead->cone_p4()+selHadTau->p4()).mass();
+    double m_l3tau = (selLepton_third->cone_p4()+selHadTau->p4()).mass();
     double m_ltau_closestToZ = m_l1tau;
     double m_OS_ltau_closestToZ = -1;
     if(selLepton_lead->charge()!=selHadTau->charge()) m_OS_ltau_closestToZ = m_l1tau;
@@ -2486,21 +2486,21 @@ int main(int argc, char* argv[])
 	  }
 	}
       }
-      const double deltaEta_lep1_lep2 = (selLepton_lead->p4() - selLepton_sublead->p4()).eta();
-      const double deltaEta_lep1_tau1 = (selLepton_lead->p4() - selHadTau->p4()).eta();
-      const double deltaEta_lep2_tau1 = (selLepton_sublead->p4() - selHadTau->p4()).eta();
-      const double deltaEta_lep1_lep3 = (selLepton_lead->p4() - selLepton_third->p4()).eta();
-      const double deltaEta_lep2_lep3 = (selLepton_sublead->p4() - selLepton_third->p4()).eta();
-      const double deltaEta_lep3_tau1 = (selLepton_third->p4() - selHadTau->p4()).eta();
+      const double deltaEta_lep1_lep2 = (selLepton_lead->cone_p4() - selLepton_sublead->cone_p4()).eta();
+      const double deltaEta_lep1_tau1 = (selLepton_lead->cone_p4() - selHadTau->p4()).eta();
+      const double deltaEta_lep2_tau1 = (selLepton_sublead->cone_p4() - selHadTau->p4()).eta();
+      const double deltaEta_lep1_lep3 = (selLepton_lead->cone_p4() - selLepton_third->cone_p4()).eta();
+      const double deltaEta_lep2_lep3 = (selLepton_sublead->cone_p4() - selLepton_third->cone_p4()).eta();
+      const double deltaEta_lep3_tau1 = (selLepton_third->cone_p4() - selHadTau->p4()).eta();
       const double deltaPhi_lep1_lep2 = lep1LV.DeltaPhi(lep2LV);
       const double deltaPhi_lep1_tau1 = lep1LV.DeltaPhi(tau1LV);
       const double deltaPhi_lep2_tau1 = lep2LV.DeltaPhi(tau1LV);
       const double deltaPhi_lep1_lep3 = lep1LV.DeltaPhi(lep3LV);
       const double deltaPhi_lep2_lep3 = lep2LV.DeltaPhi(lep3LV);
       const double deltaPhi_lep3_tau1 = lep3LV.DeltaPhi(tau1LV);
-      const double m_lep1_tau1 = (selLepton_lead->p4() + selHadTau->p4()).mass();
-      const double m_lep2_tau1 = (selLepton_sublead->p4() + selHadTau->p4()).mass();
-      const double m_lep3_tau1 = (selLepton_third->p4() + selHadTau->p4()).mass();
+      const double m_lep1_tau1 = (selLepton_lead->cone_p4() + selHadTau->p4()).mass();
+      const double m_lep2_tau1 = (selLepton_sublead->cone_p4() + selHadTau->p4()).mass();
+      const double m_lep3_tau1 = (selLepton_third->cone_p4() + selHadTau->p4()).mass();
       const double dr_lep1_tau1 = deltaR(selLepton_lead->p4(),    selHadTau->p4());
       const double dr_lep2_tau1 = deltaR(selLepton_sublead->p4(), selHadTau->p4());
       const double dr_lep3_tau1 = deltaR(selLepton_third->p4(), selHadTau->p4());

--- a/bin/analyze_hh_3l_1tau.cc
+++ b/bin/analyze_hh_3l_1tau.cc
@@ -1774,7 +1774,7 @@ int main(int argc, char* argv[])
     //std::vector<SVfit4tauResult> svFit4tauResults_wMassConstraint_Z = compSVfit4tau(
     //  *selLepton_lead, *selLepton_sublead, *selLepton_third, *selHadTau, met, chargeSumSelection_string, rnd, 91.2, 2.);
 
-    double dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selHadTau->cone_p4()).mass();
+    double dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selHadTau->p4()).mass();
     //double dihiggsMass = ( svFit4tauResults_wMassConstraint.size() >= 1 && svFit4tauResults_wMassConstraint[0].isValidSolution_ ) ? 
     //  svFit4tauResults_wMassConstraint[0].dihiggs_mass_ : -1.;
 

--- a/bin/analyze_hh_4l.cc
+++ b/bin/analyze_hh_4l.cc
@@ -1439,7 +1439,7 @@ int main(int argc, char* argv[])
     double lep2_dz = selLepton_sublead->dz();
     double lep3_dz = selLepton_third->dz();
     double lep4_dz = selLepton_fourth->dz();
-    Particle::LorentzVector p4l = selLepton_lead->p4()+selLepton_sublead->p4()+selLepton_third->p4()+selLepton_fourth->p4();
+    Particle::LorentzVector p4l = selLepton_lead->cone_p4()+selLepton_sublead->cone_p4()+selLepton_third->cone_p4()+selLepton_fourth->cone_p4();
     TVector3 pt4lVetor(p4l.px(),p4l.py(),0);
     TVector3 metVector(met.p4().px(),met.p4().py(),0);
     TVector3 hadTVector = -metVector-pt4lVetor;
@@ -1486,30 +1486,30 @@ int main(int argc, char* argv[])
         nSFOS++;
     }
 
-    Particle::LorentzVector maxPtSum_pair1lep1 = selLepton_lead->p4();
-    Particle::LorentzVector maxPtSum_pair2lep1 = selLepton_sublead->p4();
-    Particle::LorentzVector maxPtSum_pair1lep2 = selLepton_third->p4();
-    Particle::LorentzVector maxPtSum_pair2lep2 = selLepton_fourth->p4();
+    Particle::LorentzVector maxPtSum_pair1lep1 = selLepton_lead->cone_p4();
+    Particle::LorentzVector maxPtSum_pair2lep1 = selLepton_sublead->cone_p4();
+    Particle::LorentzVector maxPtSum_pair1lep2 = selLepton_third->cone_p4();
+    Particle::LorentzVector maxPtSum_pair2lep2 = selLepton_fourth->cone_p4();
 
-    Particle::LorentzVector maxSubleadPt_pair1lep1 = selLepton_lead->p4();
-    Particle::LorentzVector maxSubleadPt_pair2lep1 = selLepton_sublead->p4();
-    Particle::LorentzVector maxSubleadPt_pair1lep2 = selLepton_third->p4();
-    Particle::LorentzVector maxSubleadPt_pair2lep2 = selLepton_fourth->p4();
+    Particle::LorentzVector maxSubleadPt_pair1lep1 = selLepton_lead->cone_p4();
+    Particle::LorentzVector maxSubleadPt_pair2lep1 = selLepton_sublead->cone_p4();
+    Particle::LorentzVector maxSubleadPt_pair1lep2 = selLepton_third->cone_p4();
+    Particle::LorentzVector maxSubleadPt_pair2lep2 = selLepton_fourth->cone_p4();
 
-    Particle::LorentzVector minDeltaRSum_pair1lep1 = selLepton_lead->p4();
-    Particle::LorentzVector minDeltaRSum_pair2lep1 = selLepton_sublead->p4();
-    Particle::LorentzVector minDeltaRSum_pair1lep2 = selLepton_third->p4();
-    Particle::LorentzVector minDeltaRSum_pair2lep2 = selLepton_fourth->p4();
+    Particle::LorentzVector minDeltaRSum_pair1lep1 = selLepton_lead->cone_p4();
+    Particle::LorentzVector minDeltaRSum_pair2lep1 = selLepton_sublead->cone_p4();
+    Particle::LorentzVector minDeltaRSum_pair1lep2 = selLepton_third->cone_p4();
+    Particle::LorentzVector minDeltaRSum_pair2lep2 = selLepton_fourth->cone_p4();
 
-    Particle::LorentzVector minSubclosestDeltaR_pair1lep1 = selLepton_lead->p4();
-    Particle::LorentzVector minSubclosestDeltaR_pair2lep1 = selLepton_sublead->p4();
-    Particle::LorentzVector minSubclosestDeltaR_pair1lep2 = selLepton_third->p4();
-    Particle::LorentzVector minSubclosestDeltaR_pair2lep2 = selLepton_fourth->p4();
+    Particle::LorentzVector minSubclosestDeltaR_pair1lep1 = selLepton_lead->cone_p4();
+    Particle::LorentzVector minSubclosestDeltaR_pair2lep1 = selLepton_sublead->cone_p4();
+    Particle::LorentzVector minSubclosestDeltaR_pair1lep2 = selLepton_third->cone_p4();
+    Particle::LorentzVector minSubclosestDeltaR_pair2lep2 = selLepton_fourth->cone_p4();
 
-    Particle::LorentzVector pair1lep1 = selLepton_lead->p4();
-    Particle::LorentzVector pair1lep2 = selLepton_third->p4();
-    Particle::LorentzVector pair2lep1 = selLepton_sublead->p4();
-    Particle::LorentzVector pair2lep2 = selLepton_fourth->p4();
+    Particle::LorentzVector pair1lep1 = selLepton_lead->cone_p4();
+    Particle::LorentzVector pair1lep2 = selLepton_third->cone_p4();
+    Particle::LorentzVector pair2lep1 = selLepton_sublead->cone_p4();
+    Particle::LorentzVector pair2lep2 = selLepton_fourth->cone_p4();
 
     bool lep1lep2OS = (selLepton_lead->charge() != selLepton_sublead->charge());
     bool lep1lep3OS = (selLepton_lead->charge() != selLepton_third->charge());
@@ -1518,8 +1518,8 @@ int main(int argc, char* argv[])
       {
 	if (!lep1lep3OS)
 	  {
-	    pair1lep2 = selLepton_fourth->p4();
-	    pair2lep2 = selLepton_third->p4();
+            pair1lep2 = selLepton_fourth->cone_p4();
+            pair2lep2 = selLepton_third->cone_p4();
 	  }
 	if ((pair1lep1 + pair1lep2).mass() < 130 && (pair2lep1 + pair2lep2).mass() < 130)
 	  {
@@ -1545,10 +1545,10 @@ int main(int argc, char* argv[])
 	  }
 	else
 	  {
-	    pair1lep1 = selLepton_lead->p4();
-	    pair1lep2 = selLepton_sublead->p4();
-	    pair2lep1 = selLepton_third->p4();
-	    pair2lep2 = selLepton_fourth->p4();
+            pair1lep1 = selLepton_lead->cone_p4();
+            pair1lep2 = selLepton_sublead->cone_p4();
+            pair2lep1 = selLepton_third->cone_p4();
+            pair2lep2 = selLepton_fourth->cone_p4();
 	    if ((pair1lep1 + pair1lep2).mass() < 130 && (pair2lep1 + pair2lep2).mass() < 130)
 	      {
 		maxPtSum_pair1lep1 = pair1lep1;
@@ -1575,25 +1575,25 @@ int main(int argc, char* argv[])
 	      {
 		if (lep1lep3OS)
 		  {
-		    pair1lep1 = selLepton_lead->p4();
-		    pair1lep2 = selLepton_third->p4();
-		    pair2lep1 = selLepton_sublead->p4();
-		    pair2lep2 = selLepton_fourth->p4();
+                    pair1lep1 = selLepton_lead->cone_p4();
+                    pair1lep2 = selLepton_third->cone_p4();
+                    pair2lep1 = selLepton_sublead->cone_p4();
+                    pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
-		    pair1lep1 = selLepton_lead->p4();
-		    pair1lep2 = selLepton_fourth->p4();
-		    pair2lep1 = selLepton_sublead->p4();
-		    pair2lep2 = selLepton_third->p4();
+                    pair1lep1 = selLepton_lead->cone_p4();
+                    pair1lep2 = selLepton_fourth->cone_p4();
+                    pair2lep1 = selLepton_sublead->cone_p4();
+                    pair2lep2 = selLepton_third->cone_p4();
 		  }
-		if ((selLepton_lead->p4() + selLepton_sublead->p4()).pt() + (selLepton_third->p4() + selLepton_fourth->p4()).pt() >
+                if ((selLepton_lead->cone_p4() + selLepton_sublead->cone_p4()).pt() + (selLepton_third->cone_p4() + selLepton_fourth->cone_p4()).pt() >
 		    (pair1lep1 + pair1lep2).pt() + (pair2lep1 + pair2lep2).pt())
 		  {
-		    maxPtSum_pair1lep1 = selLepton_lead->p4();
-		    maxPtSum_pair1lep2 = selLepton_sublead->p4();
-		    maxPtSum_pair2lep1 = selLepton_third->p4();
-		    maxPtSum_pair2lep2 = selLepton_fourth->p4();
+                    maxPtSum_pair1lep1 = selLepton_lead->cone_p4();
+                    maxPtSum_pair1lep2 = selLepton_sublead->cone_p4();
+                    maxPtSum_pair2lep1 = selLepton_third->cone_p4();
+                    maxPtSum_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
@@ -1603,13 +1603,13 @@ int main(int argc, char* argv[])
 		    maxPtSum_pair2lep2 = pair2lep2;
 		  }
 
-		if (std::min((selLepton_lead->p4() + selLepton_sublead->p4()).pt(), (selLepton_third->p4() + selLepton_fourth->p4()).pt()) >
+                if (std::min((selLepton_lead->cone_p4() + selLepton_sublead->cone_p4()).pt(), (selLepton_third->cone_p4() + selLepton_fourth->cone_p4()).pt()) >
 		    std::min((pair1lep1 + pair1lep2).pt(), (pair2lep1 + pair2lep2).pt()))
 		  {
-		    maxSubleadPt_pair1lep1 = selLepton_lead->p4();
-		    maxSubleadPt_pair1lep2 = selLepton_sublead->p4();
-		    maxSubleadPt_pair2lep1 = selLepton_third->p4();
-		    maxSubleadPt_pair2lep2 = selLepton_fourth->p4();
+                    maxSubleadPt_pair1lep1 = selLepton_lead->cone_p4();
+                    maxSubleadPt_pair1lep2 = selLepton_sublead->cone_p4();
+                    maxSubleadPt_pair2lep1 = selLepton_third->cone_p4();
+                    maxSubleadPt_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
@@ -1619,13 +1619,13 @@ int main(int argc, char* argv[])
 		    maxSubleadPt_pair2lep2 = pair2lep2;
 		  }
 
-		if (deltaR(selLepton_lead->p4(), selLepton_sublead->p4()) + deltaR(selLepton_third->p4(), selLepton_fourth->p4()) <
+                if (deltaR(selLepton_lead->cone_p4(), selLepton_sublead->cone_p4()) + deltaR(selLepton_third->cone_p4(), selLepton_fourth->cone_p4()) <
 		    deltaR(pair1lep1, pair1lep2) + deltaR(pair2lep1, pair2lep2))
 		  {
-		    minDeltaRSum_pair1lep1 = selLepton_lead->p4();
-		    minDeltaRSum_pair1lep2 = selLepton_sublead->p4();
-		    minDeltaRSum_pair2lep1 = selLepton_third->p4();
-		    minDeltaRSum_pair2lep2 = selLepton_fourth->p4();
+                    minDeltaRSum_pair1lep1 = selLepton_lead->cone_p4();
+                    minDeltaRSum_pair1lep2 = selLepton_sublead->cone_p4();
+                    minDeltaRSum_pair2lep1 = selLepton_third->cone_p4();
+                    minDeltaRSum_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
@@ -1635,13 +1635,13 @@ int main(int argc, char* argv[])
 		    minDeltaRSum_pair2lep2 = pair2lep2;
 		  }
 
-		if (std::max(deltaR(selLepton_lead->p4(), selLepton_sublead->p4()), deltaR(selLepton_third->p4(), selLepton_fourth->p4())) <
+                if (std::max(deltaR(selLepton_lead->cone_p4(), selLepton_sublead->cone_p4()), deltaR(selLepton_third->cone_p4(), selLepton_fourth->cone_p4())) <
 		    std::max(deltaR(pair1lep1, pair1lep2), deltaR(pair2lep1, pair2lep2)))
 		  {
-		    minSubclosestDeltaR_pair1lep1 = selLepton_lead->p4();
-		    minSubclosestDeltaR_pair1lep2 = selLepton_sublead->p4();
-		    minSubclosestDeltaR_pair2lep1 = selLepton_third->p4();
-		    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->p4();
+                    minSubclosestDeltaR_pair1lep1 = selLepton_lead->cone_p4();
+                    minSubclosestDeltaR_pair1lep2 = selLepton_sublead->cone_p4();
+                    minSubclosestDeltaR_pair2lep1 = selLepton_third->cone_p4();
+                    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
@@ -1679,8 +1679,8 @@ int main(int argc, char* argv[])
 	  }
 	else
 	  {
-	    pair1lep2 = selLepton_fourth->p4();
-	    pair2lep2 = selLepton_third->p4();
+            pair1lep2 = selLepton_fourth->cone_p4();
+            pair2lep2 = selLepton_third->cone_p4();
 	    if ((pair1lep1 + pair1lep2).mass() < 130 && (pair2lep1 + pair2lep2).mass() < 130)
 	      {
 		maxPtSum_pair1lep1 = pair1lep1;
@@ -1705,68 +1705,68 @@ int main(int argc, char* argv[])
 	      }
 	    else
 	      {
-		if ((selLepton_lead->p4() + selLepton_third->p4()).pt() + (selLepton_sublead->p4() + selLepton_fourth->p4()).pt() >
-		    (selLepton_lead->p4() + selLepton_fourth->p4()).pt() + (selLepton_sublead->p4() + selLepton_third->p4()).pt())
+                if ((selLepton_lead->cone_p4() + selLepton_third->cone_p4()).pt() + (selLepton_sublead->cone_p4() + selLepton_fourth->cone_p4()).pt() >
+                    (selLepton_lead->cone_p4() + selLepton_fourth->cone_p4()).pt() + (selLepton_sublead->cone_p4() + selLepton_third->cone_p4()).pt())
 		  {
-		    maxPtSum_pair1lep1 = selLepton_lead->p4();
-		    maxPtSum_pair1lep2 = selLepton_third->p4();
-		    maxPtSum_pair2lep1 = selLepton_sublead->p4();
-		    maxPtSum_pair2lep2 = selLepton_fourth->p4();
+                    maxPtSum_pair1lep1 = selLepton_lead->cone_p4();
+                    maxPtSum_pair1lep2 = selLepton_third->cone_p4();
+                    maxPtSum_pair2lep1 = selLepton_sublead->cone_p4();
+                    maxPtSum_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
-		    maxPtSum_pair1lep1 = selLepton_lead->p4();
-		    maxPtSum_pair1lep2 = selLepton_fourth->p4();
-		    maxPtSum_pair2lep1 = selLepton_sublead->p4();
-		    maxPtSum_pair2lep2 = selLepton_third->p4();
+                    maxPtSum_pair1lep1 = selLepton_lead->cone_p4();
+                    maxPtSum_pair1lep2 = selLepton_fourth->cone_p4();
+                    maxPtSum_pair2lep1 = selLepton_sublead->cone_p4();
+                    maxPtSum_pair2lep2 = selLepton_third->cone_p4();
 		  }
 
-		if (std::min((selLepton_lead->p4() + selLepton_third->p4()).pt(), (selLepton_sublead->p4() + selLepton_fourth->p4()).pt()) >
-		    std::min((selLepton_lead->p4() + selLepton_fourth->p4()).pt(), (selLepton_sublead->p4() + selLepton_third->p4()).pt()))
+                if (std::min((selLepton_lead->cone_p4() + selLepton_third->cone_p4()).pt(), (selLepton_sublead->cone_p4() + selLepton_fourth->cone_p4()).pt()) >
+                    std::min((selLepton_lead->cone_p4() + selLepton_fourth->cone_p4()).pt(), (selLepton_sublead->cone_p4() + selLepton_third->cone_p4()).pt()))
 		  {
-		    maxSubleadPt_pair1lep1 = selLepton_lead->p4();
-		    maxSubleadPt_pair1lep2 = selLepton_third->p4();
-		    maxSubleadPt_pair2lep1 = selLepton_sublead->p4();
-		    maxSubleadPt_pair2lep2 = selLepton_fourth->p4();
+                    maxSubleadPt_pair1lep1 = selLepton_lead->cone_p4();
+                    maxSubleadPt_pair1lep2 = selLepton_third->cone_p4();
+                    maxSubleadPt_pair2lep1 = selLepton_sublead->cone_p4();
+                    maxSubleadPt_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
-		    maxSubleadPt_pair1lep1 = selLepton_lead->p4();
-		    maxSubleadPt_pair1lep2 = selLepton_fourth->p4();
-		    maxSubleadPt_pair2lep1 = selLepton_sublead->p4();
-		    maxSubleadPt_pair2lep2 = selLepton_third->p4();
+                    maxSubleadPt_pair1lep1 = selLepton_lead->cone_p4();
+                    maxSubleadPt_pair1lep2 = selLepton_fourth->cone_p4();
+                    maxSubleadPt_pair2lep1 = selLepton_sublead->cone_p4();
+                    maxSubleadPt_pair2lep2 = selLepton_third->cone_p4();
 		  }
 
-		if (deltaR(selLepton_lead->p4(), selLepton_third->p4()) + deltaR(selLepton_sublead->p4(), selLepton_fourth->p4()) <
-		    deltaR(selLepton_lead->p4(), selLepton_fourth->p4()) + deltaR(selLepton_sublead->p4(), selLepton_third->p4()))
+                if (deltaR(selLepton_lead->cone_p4(), selLepton_third->cone_p4()) + deltaR(selLepton_sublead->cone_p4(), selLepton_fourth->cone_p4()) <
+                    deltaR(selLepton_lead->cone_p4(), selLepton_fourth->cone_p4()) + deltaR(selLepton_sublead->cone_p4(), selLepton_third->cone_p4()))
 		  {
-		    minDeltaRSum_pair1lep1 = selLepton_lead->p4();
-		    minDeltaRSum_pair1lep2 = selLepton_third->p4();
-		    minDeltaRSum_pair2lep1 = selLepton_sublead->p4();
-		    minDeltaRSum_pair2lep2 = selLepton_fourth->p4();
+                    minDeltaRSum_pair1lep1 = selLepton_lead->cone_p4();
+                    minDeltaRSum_pair1lep2 = selLepton_third->cone_p4();
+                    minDeltaRSum_pair2lep1 = selLepton_sublead->cone_p4();
+                    minDeltaRSum_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
-		    minDeltaRSum_pair1lep1 = selLepton_lead->p4();
-		    minDeltaRSum_pair1lep2 = selLepton_fourth->p4();
-		    minDeltaRSum_pair2lep1 = selLepton_sublead->p4();
-		    minDeltaRSum_pair2lep2 = selLepton_third->p4();
+                    minDeltaRSum_pair1lep1 = selLepton_lead->cone_p4();
+                    minDeltaRSum_pair1lep2 = selLepton_fourth->cone_p4();
+                    minDeltaRSum_pair2lep1 = selLepton_sublead->cone_p4();
+                    minDeltaRSum_pair2lep2 = selLepton_third->cone_p4();
 		  }
 
-		if (std::max(deltaR(selLepton_lead->p4(), selLepton_third->p4()), deltaR(selLepton_sublead->p4(), selLepton_fourth->p4())) <
-		    std::max(deltaR(selLepton_lead->p4(), selLepton_fourth->p4()), deltaR(selLepton_sublead->p4(), selLepton_third->p4())))
+                if (std::max(deltaR(selLepton_lead->cone_p4(), selLepton_third->cone_p4()), deltaR(selLepton_sublead->cone_p4(), selLepton_fourth->cone_p4())) <
+                    std::max(deltaR(selLepton_lead->cone_p4(), selLepton_fourth->cone_p4()), deltaR(selLepton_sublead->cone_p4(), selLepton_third->cone_p4())))
 		  {
-		    minSubclosestDeltaR_pair1lep1 = selLepton_lead->p4();
-		    minSubclosestDeltaR_pair1lep2 = selLepton_third->p4();
-		    minSubclosestDeltaR_pair2lep1 = selLepton_sublead->p4();
-		    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->p4();
+                    minSubclosestDeltaR_pair1lep1 = selLepton_lead->cone_p4();
+                    minSubclosestDeltaR_pair1lep2 = selLepton_third->cone_p4();
+                    minSubclosestDeltaR_pair2lep1 = selLepton_sublead->cone_p4();
+                    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 		else
 		  {
-		    minSubclosestDeltaR_pair1lep1 = selLepton_lead->p4();
-		    minSubclosestDeltaR_pair1lep2 = selLepton_third->p4();
-		    minSubclosestDeltaR_pair2lep1 = selLepton_sublead->p4();
-		    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->p4();
+                    minSubclosestDeltaR_pair1lep1 = selLepton_lead->cone_p4();
+                    minSubclosestDeltaR_pair1lep2 = selLepton_third->cone_p4();
+                    minSubclosestDeltaR_pair2lep1 = selLepton_sublead->cone_p4();
+                    minSubclosestDeltaR_pair2lep2 = selLepton_fourth->cone_p4();
 		  }
 	      }
 	  }
@@ -2153,7 +2153,7 @@ int main(int argc, char* argv[])
     // std::vector<SVfit4tauResult> svFit4tauResults_wMassConstraint = compSVfit4tau(
     //   *selLepton_lead, *selLepton_sublead, *selLepton_third, *selLepton_fourth, met, leptonChargeSelection_string, rnd, 125., 2.);
         
-    double dihiggsVisMass_sel = (selLepton_lead->p4() + selLepton_sublead->p4() + selLepton_third->p4() + selLepton_fourth->p4()).mass();
+    double dihiggsVisMass_sel = (selLepton_lead->cone_p4() + selLepton_sublead->cone_p4() + selLepton_third->cone_p4() + selLepton_fourth->cone_p4()).mass();
     double dihiggsMass = -10; // ( svFit4tauResults_wMassConstraint.size() >= 1 && svFit4tauResults_wMassConstraint[0].isValidSolution_ ) ? 
     //   svFit4tauResults_wMassConstraint[0].dihiggs_mass_ : -1.;
 


### PR DESCRIPTION
Use `cone_p4` instead of `p4` in all analysis channels, except for 0l+4tau (because there are no leptons in the final state), in 2lss+<=1tau (because the feature is implemented in https://github.com/HEP-KBFI/hh-multilepton/pull/42), and in dedicated CR and study analyses.

edit: forgot to point out that it doesn't matter if we use `p4` or `cone_p4` when computing `deltaR`, and also kept using `p4` when applying the Z veto.